### PR TITLE
Use Gleam casing in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gleam add gserde
 ```gleam
 // src/foo.gleam
 import gleam/option.{type Option}
-pub type FooJSON {
+pub type FooJson {
   Foo(
     a_bool: Bool,
     b_int: Int,


### PR DESCRIPTION
Hello!

"FooJSON" would be "foo j s o n", while "FooJson is "foo json".

Thanks,
Louis